### PR TITLE
make products a flat list so item search works again

### DIFF
--- a/.github/scripts/generate.py
+++ b/.github/scripts/generate.py
@@ -26,7 +26,7 @@ class TipToiCatalog:
         LOGGER.info("Start data scraping")
         self.get_catalog(target)
         for product in self.catalog:
-            self.products.append(self.get_product_data(product))
+            self.products.extend(self.get_product_data(product))
             time.sleep(0.1)
         self.persist_products()
 


### PR DESCRIPTION
#11 erroneously made products a nested list so search did not work correctly. This is fixed here.

@Bouni Mind to merge again? Sorry for the hassle.